### PR TITLE
Fix the table of integer values on setopt page

### DIFF
--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -980,10 +980,10 @@
             <para>
              <parameter>CURLAUTH_NONE</parameter> allows no authentication.
             </para>
-           </entry>
-           <entry valign="top">
-            Defaults to <literal>CURLAUTH_BASIC|CURLAUTH_GSSAPI</literal>.
-            Set the actual username and password with the <constant>CURLOPT_PROXYUSERPWD</constant> option.
+            <para>
+             Defaults to <literal>CURLAUTH_BASIC|CURLAUTH_GSSAPI</literal>.
+             Set the actual username and password with the <constant>CURLOPT_PROXYUSERPWD</constant> option.
+            </para>
            </entry>
            <entry valign="top">
             Available as of 7.3.0 and curl >= 7.55.0.


### PR DESCRIPTION
CURLOPT_SOCKS5_AUTH has one extra entry tag, so it's making the table have 4 columns.
This PR makes the extra <entry></entry> another <para></para> tag to fix the table.